### PR TITLE
Optional.None instead of empty string

### DIFF
--- a/Classes/MIBadgeButton.swift
+++ b/Classes/MIBadgeButton.swift
@@ -39,13 +39,13 @@ public class MIBadgeButton: UIButton {
         badgeLabel = UILabel()
         super.init(frame: frame)
         // Initialization code
-        setupBadgeViewWithString(badgeText: "")
+        setupBadgeViewWithString(badgeText: Optional.None)
     }
     
     required public init?(coder aDecoder: NSCoder) {
         badgeLabel = UILabel()
         super.init(coder: aDecoder)
-        setupBadgeViewWithString(badgeText: "")
+        setupBadgeViewWithString(badgeText: Optional.None)
     }
     
     public func initWithFrame(frame frame: CGRect, withBadgeString badgeString: String, withBadgeInsets badgeInsets: UIEdgeInsets) -> AnyObject {
@@ -84,7 +84,7 @@ public class MIBadgeButton: UIButton {
         setupBadgeStyle()
         addSubview(badgeLabel)
         
-        badgeLabel.hidden = badgeText != nil ? false : true
+        badgeLabel.hidden = badgeText != Optional.None ? false : true
     }
     
     private func setupBadgeStyle() {


### PR DESCRIPTION
Passing Optional.None instead of empty string in setupBadgeViewWithString upon initializing from Interface Builder.

If an empty string is passed in those functions, when you initialize the badge from IB it will show an empty circle, but the badge should be hidden.

![simulator screen shot mar 23 2016 4 32 00 pm](https://cloud.githubusercontent.com/assets/6389088/13990472/cae68eb4-f114-11e5-9fd2-55aa9463ee68.png)
