### PR TITLE
Badge anchor

### DIFF
--- a/Classes/MIBadgeButton.swift
+++ b/Classes/MIBadgeButton.swift
@@ -8,12 +8,97 @@
 
 import UIKit
 
+/**
+ Define badge anchor
+ **/
+public enum MIAnchor{
+    case TopLeft(topOffset : CGFloat, leftOffset : CGFloat)
+    case TopRight(topOffset : CGFloat, rightOffset : CGFloat)
+    case BottomLeft(bottomOffset : CGFloat, leftOffset : CGFloat)
+    case BottomRight(bottomOffset : CGFloat, rightOffset : CGFloat)
+    case center
+}
+
+@IBDesignable
 open class MIBadgeButton: UIButton {
     
     fileprivate var badgeLabel: UILabel
+    
+    @IBInspectable
     open var badgeString: String? {
         didSet {
             setupBadgeViewWithString(badgeText: badgeString)
+        }
+    }
+    
+    /**
+     Factor that can change corner radius of badge
+     
+     This value will be calculate like:
+     (Badge Label Height) / (this value)
+    **/
+    @IBInspectable
+    open var cornerRadiusFactor : CGFloat = 2{
+        
+        didSet{
+            setupBadgeViewWithString(badgeText: badgeString)
+        }
+    }
+    
+    /**
+     Vertical margin in badge
+     This is the space between text and badge's vertical edge
+    **/
+    fileprivate var innerVerticalMargin : CGFloat = 5.0{
+        
+        didSet{
+            setupBadgeViewWithString(badgeText: badgeString)
+        }
+    }
+    
+    /**
+     Horizontal margin in badge
+     This is the space between text and badge's horizontal edge
+     **/
+    fileprivate var innerHorizontalMargin : CGFloat = 10.0{
+        
+        didSet{
+            setupBadgeViewWithString(badgeText: badgeString)
+        }
+    }
+    
+    /**
+     Vertical margin in badge
+     This is the space between text and badge's vertical edge
+     **/
+    @IBInspectable
+    open var verticalMargin : CGFloat{
+        
+        set{
+            
+            self.innerVerticalMargin = max(0, newValue)
+        }
+        
+        get{
+            
+            return innerVerticalMargin
+        }
+    }
+    
+    /**
+     Horizontal margin in badge
+     This is the space between text and badge's horizontal edge
+     **/
+    @IBInspectable
+    open var horizontalMargin : CGFloat{
+        
+        set{
+            self.innerHorizontalMargin = max(0, newValue)
+        }
+        
+        get{
+            
+            return innerHorizontalMargin
         }
     }
     
@@ -23,17 +108,282 @@ open class MIBadgeButton: UIButton {
         }
     }
     
-    open var badgeBackgroundColor = UIColor.red {
+    @IBInspectable
+    open var badgeBackgroundColor : UIColor = UIColor.red {
         didSet {
             badgeLabel.backgroundColor = badgeBackgroundColor
         }
     }
     
-    open var badgeTextColor = UIColor.white {
+    @IBInspectable
+    open var badgeTextColor : UIColor = UIColor.white {
         didSet {
             badgeLabel.textColor = badgeTextColor
         }
     }
+    
+    /**
+     Can be adjust from Interface Builder
+     EdgeInsetLeft
+    **/
+    @IBInspectable
+    open var edgeInsetLeft : CGFloat{
+        set{
+
+            if let edgeInset = badgeEdgeInsets{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: edgeInset.top, left: newValue, bottom: edgeInset.bottom, right: edgeInset.right)
+            }
+            else{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: 0.0, left: newValue, bottom: 0.0, right: 0.0)
+            }
+        }
+        get{
+            
+            if let edgeInset = badgeEdgeInsets{
+                return edgeInset.left
+            }
+            
+            return 0.0
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     EdgeInsetRight
+     **/
+    @IBInspectable
+    open var edgeInsetRight : CGFloat{
+        set{
+            
+            if let edgeInset = badgeEdgeInsets{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: edgeInset.top, left: edgeInset.left, bottom: edgeInset.bottom, right: newValue)
+            }
+            else{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: newValue)
+            }
+        }
+        get{
+            
+            if let edgeInset = badgeEdgeInsets{
+                return edgeInset.right
+            }
+            
+            return 0.0
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     EdgeInsetTop
+     **/
+    @IBInspectable
+    open var edgeInsetTop : CGFloat{
+        set{
+            
+            if let edgeInset = badgeEdgeInsets{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: newValue, left: edgeInset.left, bottom: edgeInset.bottom, right: edgeInset.right)
+            }
+            else{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: newValue, left: 0.0, bottom: 0.0, right: 0.0)
+            }
+        }
+        get{
+            
+            if let edgeInset = badgeEdgeInsets{
+                return edgeInset.top
+            }
+            
+            return 0.0
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     EdgeInsetBottom
+     **/
+    @IBInspectable
+    open var edgeInsetBottom : CGFloat{
+        set{
+            
+            if let edgeInset = badgeEdgeInsets{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: edgeInset.top, left: edgeInset.left, bottom: newValue, right: edgeInset.right)
+            }
+            else{
+                
+                self.badgeEdgeInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: newValue, right: 0.0)
+            }
+        }
+        get{
+            
+            if let edgeInset = badgeEdgeInsets{
+                return edgeInset.bottom
+            }
+            
+            return 0.0
+        }
+    }
+    
+    /**
+     Badge's anchor. TopLeft, TopRight, BottomLeft, BottomRight and Center
+     Offset is required depend on anchor. Assign 0.0 if don't need offset
+     
+     Note: badgeEdgeInsets are taking into count when calculate position
+     **/
+    open var badgeAnchor : MIAnchor = .TopRight(topOffset: 0.0, rightOffset: 0.0){
+        didSet{
+            setupBadgeViewWithString(badgeText: badgeString)
+        }
+    }
+    
+    /**
+     AnchorIndex is an Integer value from 0 to 4 each value represent different anchor of badge
+     
+     0 = TopLeft
+     
+     1 = TopRight
+     
+     2 = BottomLeft
+     
+     3 = BottomRight
+     
+     4 = Center
+     **/
+    fileprivate var anchorIndex : Int = 0{
+        didSet{
+            
+            switch anchorIndex {
+            case 0:
+                self.badgeAnchor = .TopLeft(topOffset: topOffset, leftOffset: leftOffset)
+                break
+            case 1:
+                self.badgeAnchor = .TopRight(topOffset: topOffset, rightOffset: rightOffset)
+                break
+            case 2:
+                self.badgeAnchor = .BottomLeft(bottomOffset: buttomOffset, leftOffset: leftOffset)
+                break
+            case 3:
+                self.badgeAnchor = .BottomRight(bottomOffset: buttomOffset, rightOffset: rightOffset)
+                break
+            case 4:
+                self.badgeAnchor = .center
+                break
+            default:
+                print("Unknow anchor position. Fallback to default")
+                self.anchorIndex  = 1
+            }
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     It represent different anchor on button
+     Values are 0 ~ 4
+     
+     0 = TopLeft
+     
+     1 = TopRight
+     
+     2 = BottomLeft
+     
+     3 = BottomRight
+     
+     4 = Center
+    **/
+    @IBInspectable
+    open var anchor : Int{
+        set{
+            
+            self.anchorIndex = min(max(0, newValue), 4)
+        }
+        
+        get{
+            return self.anchorIndex
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     Left offset of anchor
+     
+     Value is effect when anchor are:
+     
+     TopLeft
+     
+     BottomLeft
+     **/
+    @IBInspectable
+    open var leftOffset : CGFloat = 0{
+        didSet{
+            
+            //get anchor of index and assign to anchorIndex
+            //to trigger view to update
+            let ach = anchor
+            self.anchorIndex = ach
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     Right offset of anchor
+     
+     Value is effect when anchor are:
+     
+     TopRight
+     
+     BottomRight
+     **/
+    @IBInspectable
+    open var rightOffset : CGFloat = 0{
+        didSet{
+            let ach = anchor
+            self.anchorIndex = ach
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     Top offset of anchor
+     
+     Value is effect when anchor are:
+     
+     TopLeft
+     
+     TopRight
+     **/
+    @IBInspectable
+    open var topOffset : CGFloat = 0{
+        didSet{
+            let ach = anchor
+            self.anchorIndex = ach
+        }
+    }
+    
+    /**
+     Can be adjust from Interface Builder
+     Bottom offset of anchor
+     
+     Value is effect when anchor are:
+     
+     BottomLeft
+     
+     BottomRight
+     **/
+    @IBInspectable
+    open var buttomOffset : CGFloat = 0{
+        didSet{
+            let ach = anchor
+            self.anchorIndex = ach
+        }
+    }
+    
+
 
     override public init(frame: CGRect) {
         badgeLabel = UILabel()
@@ -48,10 +398,11 @@ open class MIBadgeButton: UIButton {
         setupBadgeViewWithString(badgeText: "")
     }
     
-    open func initWithFrame(frame: CGRect, withBadgeString badgeString: String, withBadgeInsets badgeInsets: UIEdgeInsets) -> AnyObject {
+    open func initWithFrame(frame: CGRect, withBadgeString badgeString: String, withBadgeInsets badgeInsets: UIEdgeInsets, badgeAnchor : MIAnchor = .TopRight(topOffset: 0.0, rightOffset: 0.0)) -> AnyObject {
         
         badgeLabel = UILabel()
         badgeEdgeInsets = badgeInsets
+        self.badgeAnchor = badgeAnchor
         setupBadgeViewWithString(badgeText: badgeString)
         return self
     }
@@ -61,7 +412,7 @@ open class MIBadgeButton: UIButton {
         super.layoutSubviews()
         setupBadgeViewWithString(badgeText: self.badgeString)
     }
-    
+    /*
     fileprivate func setupBadgeViewWithString(badgeText: String?) {
         badgeLabel.clipsToBounds = true
         badgeLabel.text = badgeText
@@ -97,11 +448,90 @@ open class MIBadgeButton: UIButton {
         }
         
     }
+    */
+    fileprivate func setupBadgeViewWithString(badgeText: String?){
+        badgeLabel.clipsToBounds = true
+        badgeLabel.text = badgeText
+        badgeLabel.font = UIFont.systemFont(ofSize: 12)
+        badgeLabel.textAlignment = .center
+        badgeLabel.sizeToFit()
+        let badgeSize = badgeLabel.bounds.size
+        
+        let height = max(20, CGFloat(badgeSize.height) + innerVerticalMargin)
+        let width = max(height, CGFloat(badgeSize.width) + innerHorizontalMargin)
+        
+        var vertical: CGFloat, horizontal: CGFloat
+        var x : CGFloat = 0, y : CGFloat = 0
+        
+        if let badgeInset = self.badgeEdgeInsets{
+            
+            vertical = CGFloat(badgeInset.top) - CGFloat(badgeInset.bottom)
+            horizontal = CGFloat(badgeInset.left) - CGFloat(badgeInset.right)
+            
+        }
+        else{
+            
+            vertical = 0.0
+            horizontal = 0.0
+        }
+        
+        //calculate badge X Y position
+        calculateXYForBadge(x: &x, y: &y, badgeSize: CGSize(width: width, height: height))
+        
+        //add badgeEdgeInset
+        x = x + horizontal
+        y = y + vertical
+        
+        badgeLabel.frame = CGRect(x: x, y: y, width: width, height: height)
+        
+        setupBadgeStyle()
+        addSubview(badgeLabel)
+        
+        if let text = badgeText {
+            badgeLabel.isHidden = text != "" ? false : true
+        } else {
+            badgeLabel.isHidden = true
+        }
+
+    }
+    
+    /**
+     Calculate badge's X Y position.
+     Offset are taking into count
+    **/
+    fileprivate func calculateXYForBadge(x : inout CGFloat, y : inout CGFloat, badgeSize : CGSize){
+        
+        switch self.badgeAnchor {
+            
+        case .TopLeft(let topOffset, let leftOffset):
+            x = -badgeSize.width/2 + leftOffset
+            y = -badgeSize.height/2 + topOffset
+            break
+            
+        case .TopRight(let topOffset, let rightOffset):
+            x = self.bounds.size.width - badgeSize.width/2 + rightOffset
+            y = -badgeSize.height/2 + topOffset
+            break
+            
+        case .BottomLeft(let bottomOffset, let leftOffset):
+            x = -badgeSize.width/2 + leftOffset
+            y = self.bounds.size.height - badgeSize.height/2 + bottomOffset
+            break
+        case .BottomRight(let bottomOffset, let rightOffset):
+            x = self.bounds.size.width - badgeSize.width/2 + rightOffset
+            y = self.bounds.size.height - badgeSize.height/2 + bottomOffset
+            break
+        case .center:
+            x = self.bounds.size.width/2 - badgeSize.width/2
+            y = self.bounds.size.height/2 - badgeSize.height/2
+            break
+        }
+    }
     
     fileprivate func setupBadgeStyle() {
         badgeLabel.textAlignment = .center
         badgeLabel.backgroundColor = badgeBackgroundColor
         badgeLabel.textColor = badgeTextColor
-        badgeLabel.layer.cornerRadius = badgeLabel.bounds.size.height / 2
+        badgeLabel.layer.cornerRadius = badgeLabel.bounds.size.height / cornerRadiusFactor
     }
 }

--- a/Classes/MIBadgeButton.swift
+++ b/Classes/MIBadgeButton.swift
@@ -56,6 +56,12 @@ open class MIBadgeButton: UIButton {
         return self
     }
     
+    //For Xcode 8.x
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        setupBadgeViewWithString(badgeText: self.badgeString)
+    }
+    
     fileprivate func setupBadgeViewWithString(badgeText: String?) {
         badgeLabel.clipsToBounds = true
         badgeLabel.text = badgeText

--- a/MIBadgeButton/Base.lproj/Main.storyboard
+++ b/MIBadgeButton/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14E33b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,44 +15,39 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gfh-fY-tGI" customClass="MIBadgeButton" customModule="MIBadgeButton" customModuleProvider="target">
-                                <rect key="frame" x="267" y="516" width="64" height="64"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="64" id="E36-WJ-hEd"/>
                                     <constraint firstAttribute="height" constant="64" id="Mvh-h8-aXa"/>
                                 </constraints>
                                 <state key="normal" image="twitter">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fhS-om-uBR" customClass="MIBadgeButton" customModule="MIBadgeButton" customModuleProvider="target">
-                                <rect key="frame" x="357" y="516" width="64" height="64"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="64" id="OgY-Nd-AqZ"/>
                                     <constraint firstAttribute="height" constant="64" id="XE6-e9-JMA"/>
                                 </constraints>
                                 <state key="normal" image="pinterest">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="swift-logo-hero" translatesAutoresizingMaskIntoConstraints="NO" id="MvK-3n-Bhf">
-                                <rect key="frame" x="0.0" y="-26" width="600" height="534"/>
-                            </imageView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="swift-logo-hero" translatesAutoresizingMaskIntoConstraints="NO" id="MvK-3n-Bhf"/>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ucl-NW-9Wx" customClass="MIBadgeButton" customModule="MIBadgeButton" customModuleProvider="target">
-                                <rect key="frame" x="179" y="516" width="64" height="64"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="64" id="IYO-df-ijC"/>
                                     <constraint firstAttribute="height" constant="64" id="zl2-ar-HP8"/>
                                 </constraints>
                                 <state key="normal" image="facebook">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="gfh-fY-tGI" firstAttribute="leading" secondItem="Ucl-NW-9Wx" secondAttribute="trailing" constant="24" id="0B8-aw-WjT"/>
                             <constraint firstItem="Ucl-NW-9Wx" firstAttribute="height" secondItem="fhS-om-uBR" secondAttribute="height" id="3HC-iL-hB6"/>

--- a/MIBadgeButton/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/MIBadgeButton/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -32,6 +42,16 @@
     },
     {
       "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
     },
@@ -58,6 +78,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],


### PR DESCRIPTION
-Badge now can stick to 4 different position on button here i call it anchor, these position are TopLeft, TopRight, BottomLeft, BottomRight and Center.
Those anchors have offset values e.g when anchor set to TopLeft have 2 valid offset values, left and top respectively. You can either use offset value to do minor position adjustment or leave it zero which will no effect.

"badgeEdgeInsets" property is still taking into count when calculating X Y for badge, therefore, this become 4 different options when working with badge.
1.Leave both "badgeEdgeInsets" or anchor offset to zero, this lead to badge's center been placed at 4 different position on button
2.Change "badgeEdgeInsets" to do minor adjustment
3.Change anchor offset to do minor adjustment
4.Combine "badgeEdgeInsets" with anchor offset

-Class become designable and some properties are inspectable which mean badge's properties can be adjust in Interface Builder and visual of badge will automatically update base on those properties
