### PR TITLE
Fix layout breaking on bounds change

### DIFF
--- a/Classes/MIBadgeButton.swift
+++ b/Classes/MIBadgeButton.swift
@@ -524,4 +524,14 @@ open class MIBadgeButton: UIButton {
         badgeLabel.textColor = badgeTextColor
         badgeLabel.layer.cornerRadius = badgeLabel.bounds.size.height / cornerRadiusFactor
     }
+ 
+     /**
+        When the Button's bounds change, readjust the badge to be in the correct spot.
+        This comes into play when the button is in a stack view and needs to adjust it's size, or when a constraint is changed.
+     */
+    open override var bounds: CGRect {
+        didSet {
+            setupBadgeViewWithString(badgeText: badgeString)
+        }
+    }
 }


### PR DESCRIPTION
This request just adds a simple override at the bottom of the button code. 
The override makes it so the button will adjust the badge to be in the correct position when the button's bounds change.
Here's the complete code changed:
```swift
/**
    When the Button's bounds change, readjust the badge to be in the correct spot.
    This comes into play when the button is in a stack view and needs to adjust it's size, or when a constraint is changed.
*/
open override var bounds: CGRect {
    didSet {
        setupBadgeViewWithString(badgeText: badgeString)
    }
}
```